### PR TITLE
Hotfix: Documentation fix for SharpenProfileCard button-text property

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sharpen-com/kezuri",
   "description": "The Sharpen Design System",
   "license": "MIT",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
   "es2015": "dist/esm/index.mjs",
@@ -10,7 +10,6 @@
   "types": "dist/types/index.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
-  "unpkg": "dist/kezuri/kezuri.esm.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/coggen/kezuri.git"

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,18 @@
 
 ## Usage
 
-TBD
+Kezuri is [deployed to npm](https://www.npmjs.com/package/@sharpen-com/kezuri)
+and [served via jsDelivr CDN](https://www.jsdelivr.com/package/npm/@sharpen-com/kezuri).
+
+In short, we include Kezuri's JS and CSS from the CDN in our application template.
+
+```
+<script src="https://cdn.jsdelivr.net/npm/@sharpen-com/kezuri@0.2/dist/kezuri/kezuri.esm.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@sharpen-com/kezuri@0.2/dist/kezuri/kezuri.min.css">
+```
+
+(By only specifying the _minor_ version in the URL, Sharpen apps will
+automatically use new _patch_ versions.)
 
 ## Development
 

--- a/src/components/sharpen-profile-card/sharpen-profile-card.spec.ts
+++ b/src/components/sharpen-profile-card/sharpen-profile-card.spec.ts
@@ -1,0 +1,22 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { SharpenProfileCard } from './sharpen-profile-card';
+
+it('should render with default buttonText', async () => {
+  const page = await newSpecPage({
+    components: [SharpenProfileCard],
+    html: `<sharpen-profile-card name="Foo" initial="JA" url="https://sharpen.com"></sharpen-profile-card>`,
+  });
+  expect(page.root).toEqualHtml(`
+    <sharpen-profile-card name="Foo" initial="JA" url="https://sharpen.com"><sharpen-card border="gray" padding="large"><div class="initial">JA</div><div class="name">Foo</div><a class="sharpen-button sharpen-button--primary sharpen-button--small" href="https://sharpen.com">Select</a></sharpen-card></sharpen-profile-card>
+  `);
+});
+
+it('should render with custom buttonText', async () => {
+  const page = await newSpecPage({
+    components: [SharpenProfileCard],
+    html: `<sharpen-profile-card name="Foo" initial="JA" url="https://sharpen.com" button-text="Click Me"></sharpen-profile-card>`,
+  });
+  expect(page.root).toEqualHtml(`
+    <sharpen-profile-card button-text="Click Me" name="Foo" initial="JA" url="https://sharpen.com"><sharpen-card border="gray" padding="large"><div class="initial">JA</div><div class="name">Foo</div><a class="sharpen-button sharpen-button--primary sharpen-button--small" href="https://sharpen.com">Click Me</a></sharpen-card></sharpen-profile-card>
+  `);
+});

--- a/src/components/sharpen-profile-card/sharpen-profile-card.stories.ts
+++ b/src/components/sharpen-profile-card/sharpen-profile-card.stories.ts
@@ -21,7 +21,7 @@ export default {
       description: "Where we send the user when they click the primary button."
     }
   },
-  render: (args) => `<sharpen-profile-card name="${args.name}" initial="${args.initial}" buttonText="${args.buttonText}" url="${args.url}"></sharpen-profile-card>`
+  render: (args) => `<sharpen-profile-card name="${args.name}" initial="${args.initial}" button-text="${args.buttonText}" url="${args.url}"></sharpen-profile-card>`
 };
 
 export const Default = {

--- a/src/utils/utils.spec.ts
+++ b/src/utils/utils.spec.ts
@@ -1,19 +1,14 @@
-// import { format } from './utils';
+import { optional } from './utils';
 
-// describe('format', () => {
-//   it('returns empty string for no names defined', () => {
-//     expect(format(undefined, undefined, undefined)).toEqual('');
-//   });
+describe('optional', () => {
+  it('returns empty string if the property value is empty', () => {
+    expect(optional('prop', null)).toBe("");
+    expect(optional('prop', "")).toBe("");
+    expect(optional('prop', undefined)).toBe("");
+    expect(optional('prop', false)).toBe("");
+  });
 
-//   it('formats just first names', () => {
-//     expect(format('Joseph', undefined, undefined)).toEqual('Joseph');
-//   });
-
-//   it('formats first and last names', () => {
-//     expect(format('Joseph', undefined, 'Publique')).toEqual('Joseph Publique');
-//   });
-
-//   it('formats first, middle and last names', () => {
-//     expect(format('Joseph', 'Quincy', 'Publique')).toEqual('Joseph Quincy Publique');
-//   });
-// });
+  it('returns an HTML attribute string, prefixed by a space, if the property value is defined', () => {
+    expect(optional('prop', 'val')).toBe(' prop="val"');
+  });
+});

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,7 +1,3 @@
-// export function format(first: string, middle: string, last: string): string {
-//   return (first || '') + (middle ? ` ${middle}` : '') + (last ? ` ${last}` : '');
-// }
-
 export function optional(property, argument) {
   return (argument ? ` ${property}="${argument}"` : '')
 }


### PR DESCRIPTION
The documentation story mistakenly used camelCase for the `button-text` property instead of dash-case.

(For future reference: props in our JS code should be camelCase, but the corresponding HTML attributes are always dash-case.)

This fix corrects the documentation so that it shows correct usage of `<sharpen-profile-card>` and also includes a new unit test.

![image](https://github.com/coggen/kezuri/assets/923971/dd35baf6-b303-4d56-add3-8b8dfa991dab)

I also added package usage note in README and a unit test for the `optional` utility function.

Fixes #6 