### PR TITLE
Adds sharpen-button component.

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -36,6 +36,13 @@ export namespace Components {
     interface SharpenBack {
         "href": string;
     }
+    interface SharpenButton {
+        "authToken": string;
+        "destination": string;
+        "method": string;
+        "path": string;
+        "text": string;
+    }
     interface SharpenCard {
         /**
           * Border style
@@ -133,6 +140,12 @@ declare global {
         prototype: HTMLSharpenBackElement;
         new (): HTMLSharpenBackElement;
     };
+    interface HTMLSharpenButtonElement extends Components.SharpenButton, HTMLStencilElement {
+    }
+    var HTMLSharpenButtonElement: {
+        prototype: HTMLSharpenButtonElement;
+        new (): HTMLSharpenButtonElement;
+    };
     interface HTMLSharpenCardElement extends Components.SharpenCard, HTMLStencilElement {
     }
     var HTMLSharpenCardElement: {
@@ -215,6 +228,7 @@ declare global {
         "sharpen-alert": HTMLSharpenAlertElement;
         "sharpen-assessment-header": HTMLSharpenAssessmentHeaderElement;
         "sharpen-back": HTMLSharpenBackElement;
+        "sharpen-button": HTMLSharpenButtonElement;
         "sharpen-card": HTMLSharpenCardElement;
         "sharpen-card-content": HTMLSharpenCardContentElement;
         "sharpen-card-header": HTMLSharpenCardHeaderElement;
@@ -252,6 +266,13 @@ declare namespace LocalJSX {
     }
     interface SharpenBack {
         "href"?: string;
+    }
+    interface SharpenButton {
+        "authToken"?: string;
+        "destination"?: string;
+        "method"?: string;
+        "path"?: string;
+        "text"?: string;
     }
     interface SharpenCard {
         /**
@@ -334,6 +355,7 @@ declare namespace LocalJSX {
         "sharpen-alert": SharpenAlert;
         "sharpen-assessment-header": SharpenAssessmentHeader;
         "sharpen-back": SharpenBack;
+        "sharpen-button": SharpenButton;
         "sharpen-card": SharpenCard;
         "sharpen-card-content": SharpenCardContent;
         "sharpen-card-header": SharpenCardHeader;
@@ -356,6 +378,7 @@ declare module "@stencil/core" {
             "sharpen-alert": LocalJSX.SharpenAlert & JSXBase.HTMLAttributes<HTMLSharpenAlertElement>;
             "sharpen-assessment-header": LocalJSX.SharpenAssessmentHeader & JSXBase.HTMLAttributes<HTMLSharpenAssessmentHeaderElement>;
             "sharpen-back": LocalJSX.SharpenBack & JSXBase.HTMLAttributes<HTMLSharpenBackElement>;
+            "sharpen-button": LocalJSX.SharpenButton & JSXBase.HTMLAttributes<HTMLSharpenButtonElement>;
             "sharpen-card": LocalJSX.SharpenCard & JSXBase.HTMLAttributes<HTMLSharpenCardElement>;
             "sharpen-card-content": LocalJSX.SharpenCardContent & JSXBase.HTMLAttributes<HTMLSharpenCardContentElement>;
             "sharpen-card-header": LocalJSX.SharpenCardHeader & JSXBase.HTMLAttributes<HTMLSharpenCardHeaderElement>;

--- a/src/components/sharpen-button/sharpen-button.scss
+++ b/src/components/sharpen-button/sharpen-button.scss
@@ -1,0 +1,13 @@
+sharpen-button {
+  // For button inside form.
+  // For a, when "sharpen-button--link" class is not applied.
+  button, a {
+    outline: none;
+    background: inherit;
+    border: inherit;
+    font-size: inherit;
+    color: inherit;
+    cursor: pointer;
+    text-decoration: none;
+  }
+}

--- a/src/components/sharpen-button/sharpen-button.stories.ts
+++ b/src/components/sharpen-button/sharpen-button.stories.ts
@@ -1,0 +1,53 @@
+/**
+ * A button component that contains a text-based call to action
+ *
+ * Used as button or link that can handle all actions.
+ *
+ * NOTE: **The sharpen-button doesn't have any styles applied to it. We can apply different classes to the button.**
+ */
+export default {
+  title: 'Atoms/Sharpen Button',
+  tags: ['autodocs'],
+  argTypes: {
+    method: {
+      description: 'Action method',
+      options: ['post', 'put', 'patch', 'get'],
+      control: 'radio',
+      table: { defaultValue: { summary: 'get' } }
+    },
+    text: {
+      description: 'Text to display',
+      control: 'text'
+    },
+    authToken: {
+      description: 'Required for POST requests',
+      control: 'none'
+    },
+    destination: {
+      description: 'target to open the link in new or the same tab',
+      options: ['self', '_blank'],
+      control: 'radio',
+      table: { defaultValue: { summary: 'self' } }
+    },
+    path: {
+      description: 'URL destination',
+      control: 'text'
+    }
+  },
+  args: {
+    destination: 'self',
+    path: 'https://sharpen.com',
+    method: 'put',
+    text: 'Take Assessment',
+  },
+  render: (args) => `<sharpen-button path="${args.path}" destination="${args.destination}" method="${args.method}" class="${args.class}" text="${args.text}"></sharpen-button>`
+};
+
+export const Link = {
+  args: {
+    path: 'https://google.com',
+    method: 'get',
+    text: 'Take Assessment',
+    class: 'sharpen-button sharpen-button--link sharpen-button--small'
+  }
+}

--- a/src/components/sharpen-button/sharpen-button.tsx
+++ b/src/components/sharpen-button/sharpen-button.tsx
@@ -1,0 +1,68 @@
+import { Component, Host, Prop, h } from '@stencil/core';
+
+@Component({
+  tag: 'sharpen-button',
+  styleUrl: 'sharpen-button.scss',
+})
+
+export class SharpenButton {
+
+  @Prop() method: string = 'get';
+  @Prop() authToken: string;
+  @Prop() destination: string = 'self';
+  @Prop() text: string;
+  @Prop() path: string;
+
+  determine_button() {
+    if (['post', 'put', 'patch'].includes(this.method)) {
+      return(
+        <form action="${this.path}" method="post">
+          <input
+            type="hidden"
+            name="authenticity_token"
+            value="${this.authToken}"
+          />
+          <input type="hidden" name="_method" value="${this.method}" autocomplete="off" />
+          <button
+            type="submit"
+            id="txt-btn"
+            name="btn"
+            value="btn"
+          >
+            {this.text}
+          </button>
+        </form>
+      );
+    } else if (this.method == 'submit') {
+      return (
+        <button
+          type="submit"
+          id="txt-btn"
+          name="btn"
+          value="btn"
+        >
+          {this.text}
+        </button>
+      );
+    } else {
+      return (
+        <a
+          id="txt-btn"
+          href={this.path}
+          target={this.destination == 'self' ? `_self` : `_blank`}
+        >
+          {this.text}
+        </a>
+      );
+    }
+  }
+
+  render() {
+    return (
+      <Host>
+        {this.determine_button()}
+      </Host>
+    );
+  }
+
+}


### PR DESCRIPTION
- Added SharpenButton component. It handles the creation of buttons and links while handling requests. 

### Use case
```html
<sharpen-button path="https://www.google.com" 
                destination="self" <!-- Default-->
                method="get" <!-- Default--> 
                class="sharpen-button sharpen-button--primary sharpen-button--small" <!-- Required-->
                text="Link to Google">
</sharpen-button>

<sharpen-button path= "<%= instructors_student_path %>"
                destination="self" <!-- Default-->
                method="post"
                class="sharpen-button sharpen-button--primary sharpen-button--small" <!-- Required-->
                text="Create"
                authToken= "<%= form_ authenticity_token %>">
</sharpen-button>
```

