### PR TITLE
Update: Support for custom color and background color in Profile Card

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -100,7 +100,9 @@ export namespace Components {
         "currentUser": string;
     }
     interface SharpenProfileCard {
+        "backgroundColor": string;
         "buttonText": string;
+        "color": string;
         "initial": string;
         "name": string;
         "url": string;
@@ -317,7 +319,9 @@ declare namespace LocalJSX {
         "currentUser"?: string;
     }
     interface SharpenProfileCard {
+        "backgroundColor"?: string;
         "buttonText"?: string;
+        "color"?: string;
         "initial": string;
         "name": string;
         "url": string;

--- a/src/components/sharpen-profile-card/sharpen-profile-card.spec.ts
+++ b/src/components/sharpen-profile-card/sharpen-profile-card.spec.ts
@@ -1,7 +1,7 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { SharpenProfileCard } from './sharpen-profile-card';
 
-it('should render with default buttonText', async () => {
+it('should render with default buttonText, color, and backgroundColor', async () => {
   const page = await newSpecPage({
     components: [SharpenProfileCard],
     html: `<sharpen-profile-card name="Foo" initial="JA" url="https://sharpen.com"></sharpen-profile-card>`,
@@ -18,5 +18,35 @@ it('should render with custom buttonText', async () => {
   });
   expect(page.root).toEqualHtml(`
     <sharpen-profile-card button-text="Click Me" name="Foo" initial="JA" url="https://sharpen.com"><sharpen-card border="gray" padding="large"><div class="initial">JA</div><div class="name">Foo</div><a class="sharpen-button sharpen-button--primary sharpen-button--small" href="https://sharpen.com">Click Me</a></sharpen-card></sharpen-profile-card>
+  `);
+});
+
+it('should render with custom color', async () => {
+  const page = await newSpecPage({
+    components: [SharpenProfileCard],
+    html: `<sharpen-profile-card name="Foo" initial="JA" url="https://sharpen.com" color="#ffffff"></sharpen-profile-card>`,
+  });
+  expect(page.root).toEqualHtml(`
+    <sharpen-profile-card name="Foo" initial="JA" url="https://sharpen.com" color="#ffffff"><sharpen-card border="gray" padding="large"><div class="initial" style="color: #ffffff;">JA</div><div class="name">Foo</div><a class="sharpen-button sharpen-button--primary sharpen-button--small" href="https://sharpen.com">Select</a></sharpen-card></sharpen-profile-card>
+  `);
+});
+
+it('should render with custom background color', async () => {
+  const page = await newSpecPage({
+    components: [SharpenProfileCard],
+    html: `<sharpen-profile-card name="Foo" initial="JA" url="https://sharpen.com" background-color="#000000"></sharpen-profile-card>`,
+  });
+  expect(page.root).toEqualHtml(`
+    <sharpen-profile-card name="Foo" initial="JA" url="https://sharpen.com" background-color="#000000"><sharpen-card border="gray" padding="large"><div class="initial" style="background-color: #000000;">JA</div><div class="name">Foo</div><a class="sharpen-button sharpen-button--primary sharpen-button--small" href="https://sharpen.com">Select</a></sharpen-card></sharpen-profile-card>
+  `);
+});
+
+it('should render with custom color and background color', async () => {
+  const page = await newSpecPage({
+    components: [SharpenProfileCard],
+    html: `<sharpen-profile-card name="Foo" initial="JA" url="https://sharpen.com" color="#ffffff" background-color="#000000"></sharpen-profile-card>`,
+  });
+  expect(page.root).toEqualHtml(`
+    <sharpen-profile-card name="Foo" initial="JA" url="https://sharpen.com" color="#ffffff" background-color="#000000"><sharpen-card border="gray" padding="large"><div class="initial" style="color: #ffffff; background-color: #000000;">JA</div><div class="name">Foo</div><a class="sharpen-button sharpen-button--primary sharpen-button--small" href="https://sharpen.com">Select</a></sharpen-card></sharpen-profile-card>
   `);
 });

--- a/src/components/sharpen-profile-card/sharpen-profile-card.stories.ts
+++ b/src/components/sharpen-profile-card/sharpen-profile-card.stories.ts
@@ -1,3 +1,5 @@
+import { optional } from '../../utils/utils';
+
 /**
  * When a user logs into Sharpen, we use a grid of **profile cards** to show
  * them what learners exist in their account so they can select the learner
@@ -19,9 +21,19 @@ export default {
     },
     url: {
       description: "Where we send the user when they click the primary button."
-    }
+    },
+    color: {
+      description: "The color of the initial.",
+      control: { type: 'color' },
+      table: { defaultValue: { summary: 'var(--color-sky)' } }
+    },
+    backgroundColor: {
+      description: "The background color of the circle.",
+      control: { type: 'color' },
+      table: { defaultValue: { summary: '#0f3e88' } }
+    },
   },
-  render: (args) => `<sharpen-profile-card name="${args.name}" initial="${args.initial}" button-text="${args.buttonText}" url="${args.url}"></sharpen-profile-card>`
+  render: (args) => `<sharpen-profile-card name="${args.name}" initial="${args.initial}" button-text="${args.buttonText}" url="${args.url}"${optional('color', args.color)}${optional('background-color', args.backgroundColor)}></sharpen-profile-card>`
 };
 
 export const Default = {

--- a/src/components/sharpen-profile-card/sharpen-profile-card.tsx
+++ b/src/components/sharpen-profile-card/sharpen-profile-card.tsx
@@ -10,12 +10,19 @@ export class SharpenProfileCard {
   @Prop() initial!: string;
   @Prop() buttonText: string = "Select";
   @Prop() url!: string;
+  @Prop() color: string;
+  @Prop() backgroundColor: string;
 
   render() {
+    const initialStyle = {
+      color: this.color,
+      backgroundColor: this.backgroundColor
+    };
+
     return (
       <Host>
         <sharpen-card border="gray" padding="large">
-          <div class="initial">{this.initial}</div>
+          <div class="initial" style={initialStyle}>{this.initial}</div>
           <div class="name">{this.name}</div>
           <a class="sharpen-button sharpen-button--primary sharpen-button--small" href={this.url}>{this.buttonText}</a>
         </sharpen-card>


### PR DESCRIPTION
Closes #8

This branch adds `color` and `background-color` attributes to the `<sharpen-profile-card>` component.

```html
<sharpen-profile-card
    name="Jurickson Profar"
    initial="J"
    url="https://sharpen.com"
    color="#d81212"
    background-color="#8facf7">
  </sharpen-profile-card>
```

![image](https://github.com/coggen/kezuri/assets/923971/d1328e66-e991-4928-aae7-b2baf0dddbe1)

Includes test coverage and updated story.